### PR TITLE
Add render type functionality (canvas or SVG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# VexFlow MusicXML plugin
+# VexFlow MusicXML plugin (SVG version)
 
-This is a fork of [@ringw's spectacular fork of VexFlow](https://github.com/ringw/vexflow/tree/musicxml) that adds support for loading MusicXML documents. That effort, which quite successful, is not actively synced with the [upstream repository](https://github.com/0xfe/vexflow), so it does not enjoy the benefits of VexFlow's active development.
+This is a fork of [@mechanicalscribe's spectacular fork of VexFlow](https://github.com/mechanicalscribe/vexflow-musicxml) that adds support for loading MusicXML documents and render it in SVG instead of canvas.
 
-Given the difficult of maintaining forks for long periods, this project simply organizes @ringw's contribution as a plugin to the core VexFlow project. I've removed everything except the [files that are specific to the fork](https://github.com/ringw/vexflow/compare/0xfe:master...musicxml).
+Given limited time, now the plugin is SVG only, options between canvas and SVG will be added soon.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# VexFlow MusicXML plugin (SVG version)
+# VexFlow MusicXML plugin (Canvas & SVG version)
 
-This is a fork of [@mechanicalscribe's spectacular fork of VexFlow](https://github.com/mechanicalscribe/vexflow-musicxml) that adds support for loading MusicXML documents and render it in SVG instead of canvas.
+This is a fork of [@mechanicalscribe's fork of VexFlow-Musicxml](https://github.com/mechanicalscribe/vexflow-musicxml) that adds support for loading MusicXML documents.
 
-Given limited time, now the plugin is SVG only, options between canvas and SVG will be added soon.
+This fork adds the functionality of choosing render type, i.e. `canvas` or `svg`.
+
+To specify it, just specify `canvasType` when calling `draw`, available options are `canvas` and `svg`
+```javascript
+VexFormatter.draw(content, {canvasType: 'canvas'});
+```
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VexFormatter.draw(content, {canvasType: 'canvas'});
 
 Clone this repo and install the dependencies
 
-	git clone git@github.com:mechanicalscribe/vexflow-musicxml.git && cd vexflow-musicxml
+	git clone git@github.com:yodahuang/vexflow-musicxml.git && cd vexflow-musicxml
 	npm install
 
 This will install VexFlow and a few build dependencies to [node_modules](/node_modules). To build the plugin, just run the build script:

--- a/demo/debug.html
+++ b/demo/debug.html
@@ -41,14 +41,7 @@
         }
 
         var elapsed = (new Date().getTime() - start)/1000;
-        var debouncedResize = null;
-        $(window).resize(function() {
-          if (! debouncedResize)
-            debouncedResize = setTimeout(function() {
-              VexFormatter.draw(content);
-              debouncedResize = null;
-            }, 500);
-        });
+
       }
     });
   </script>

--- a/demo/debug.html
+++ b/demo/debug.html
@@ -37,7 +37,7 @@
         var content = $(".content")[0];
         if (VexDocument) {
           VexFormatter = VexDocument.getFormatter();
-          VexFormatter.draw(content);
+          VexFormatter.draw(content, {canvasType: 'canvas'});
         }
 
         var elapsed = (new Date().getTime() - start)/1000;

--- a/demo/index.html
+++ b/demo/index.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="initial-scale = 1.0, minimum-scale = 1.0, maximum-scale = 1.0, user-scalable = no">
 
   <!-- VexFlow Compiled Source -->
-  <!--<script src="../node_modules/vexflow/releases/vexflow-min.js"></script>-->
+  <script src="../node_modules/vexflow/releases/vexflow-min.js"></script>
   <script src="../vexflow.musicxml.js"></script>
 
   <!-- Support Sources -->
@@ -41,6 +41,7 @@
         $(window).resize(function() {
           if (! debouncedResize)
             debouncedResize = setTimeout(function() {
+              content.empty();
               VexFormatter.draw(content);
               debouncedResize = null;
             }, 500);

--- a/src/measure.js
+++ b/src/measure.js
@@ -305,7 +305,7 @@ Vex.Flow.Measure.Stave = function(object) {
   this.modifiers = new Array();
   if (object.modifiers instanceof Array) {
     for (var i = 0; i < object.modifiers.length; i++)
-      this.addModifier(object.modifiers[i]);  
+      this.addModifier(object.modifiers[i]);
   }
 
   this.type = "stave";
@@ -426,7 +426,7 @@ Vex.Flow.Measure.Note = function(object) {
                       ? new Vex.Flow.Fraction(1, 1) : null;
   this.tuplet = (typeof object.tuplet == "object" && object.tuplet)
               ? {num_notes: object.tuplet.num_notes,
-                 beats_occupied: object.tuplet.beats_occupied}
+                 notes_occupied: object.tuplet.notes_occupied}
               : null;
   this.stem_direction = (typeof object.stem_direction == "number")
                       ? object.stem_direction : null;

--- a/src/musicxml.js
+++ b/src/musicxml.js
@@ -333,13 +333,13 @@ Vex.Flow.Backend.MusicXML.prototype.parseNote = function(noteElem, attrs) {
         break;
       case "time-modification":
         var num_notes = elem.getElementsByTagName("actual-notes")[0];
-        var beats_occupied = elem.getElementsByTagName("normal-notes")[0];
-        if (num_notes && beats_occupied) {
+        var notes_occupied = elem.getElementsByTagName("normal-notes")[0];
+        if (num_notes && notes_occupied) {
           num_notes = parseInt(num_notes.textContent);
-          beats_occupied = parseInt(beats_occupied.textContent);
-          if (! (num_notes > 0 && beats_occupied > 0)) break;
-          noteObj.tickMultiplier = new Vex.Flow.Fraction(beats_occupied, num_notes);
-          noteObj.tuplet = {num_notes: num_notes, beats_occupied: beats_occupied};
+          notes_occupied = parseInt(notes_occupied.textContent);
+          if (! (num_notes > 0 && notes_occupied > 0)) break;
+          noteObj.tickMultiplier = new Vex.Flow.Fraction(notes_occupied, num_notes);
+          noteObj.tuplet = {num_notes: num_notes, notes_occupied: notes_occupied};
         }
         break;
       case "rest":


### PR DESCRIPTION
This fork adds the functionality of choosing render type, i.e. `canvas` or `svg`. 
To specify it, just specify `canvasType` when calling `draw`, available options are `canvas` and `svg` 
```javascript 
VexFormatter.draw(content, {canvasType: 'canvas'}); 
``` 

The README I merged is not quite right... please use your version of README